### PR TITLE
feat: add transportation request webapp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# itdailyreport
+# Transportation Request WebApp
+
+This repository contains a simple front-end web application for submitting and managing transportation requests for The Sands Khaolak and related hotels. The application integrates with a Google Apps Script to store and retrieve data from Google Sheets.
+
+## Files
+- `index.html` – main single-page application with Request form, HM approval, and export sections.
+- `style.css` – blue and white theme styling.
+- `script.js` – client side logic (form handling, Google Apps Script communication, charts).
+- `google-app-script.gs` – sample Google Apps Script backend to copy into Google Apps Script.
+
+## Usage
+Open `index.html` in a browser. All interactions with data rely on the published Google Apps Script endpoint defined in `script.js`.

--- a/google-app-script.gs
+++ b/google-app-script.gs
@@ -1,0 +1,102 @@
+const SHEET_ID = '1h_5QhDJrfBPv50MmLRwPE1Ftaf6FLpmXsNP9pGb1isk';
+const SHEET_NAME = 'Request';
+
+function doGet(e) {
+  const action = e.parameter.action;
+  const sheet = SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
+  if (action === 'read') {
+    const values = sheet.getDataRange().getValues();
+    const headers = values.shift();
+    const data = values.map(r => ({
+      requestNumber: r[0],
+      staffName: r[1],
+      hotel: r[2],
+      department: r[3],
+      transferType: r[4],
+      transferFrom1: r[5],
+      transferTo1: r[6],
+      transferFrom2: r[7],
+      transferTo2: r[8],
+      serviceDate: r[9],
+      carrierTime: r[10],
+      expense: r[11],
+      total: r[12],
+      reason: r[13],
+      requestBy: r[14],
+      requestDate: r[15],
+      status: r[16]
+    }));
+    return ContentService.createTextOutput(JSON.stringify(data)).setMimeType(ContentService.MimeType.JSON);
+  } else if (action === 'get') {
+    const reqNum = e.parameter.requestNumber;
+    const data = sheet.getDataRange().getValues();
+    for (let i = 1; i < data.length; i++) {
+      if (data[i][0] === reqNum) {
+        const row = data[i];
+        const obj = {
+          requestNumber: row[0],
+          staffName: row[1],
+          hotel: row[2],
+          department: row[3],
+          transferType: row[4],
+          transferFrom1: row[5],
+          transferTo1: row[6],
+          transferFrom2: row[7],
+          transferTo2: row[8],
+          serviceDate: row[9],
+          carrierTime: row[10],
+          expense: row[11],
+          total: row[12],
+          reason: row[13],
+          requestBy: row[14],
+          requestDate: row[15],
+          status: row[16]
+        };
+        return ContentService.createTextOutput(JSON.stringify(obj)).setMimeType(ContentService.MimeType.JSON);
+      }
+    }
+    return ContentService.createTextOutput('{}').setMimeType(ContentService.MimeType.JSON);
+  }
+  return ContentService.createTextOutput('unknown action');
+}
+
+function doPost(e) {
+  const data = JSON.parse(e.postData.contents);
+  const sheet = SpreadsheetApp.openById(SHEET_ID).getSheetByName(SHEET_NAME);
+  if (data.action === 'submit') {
+    const lastRow = sheet.getLastRow();
+    const nextNum = 'REQ-' + ('00000' + lastRow).slice(-5);
+    sheet.appendRow([
+      nextNum,
+      data.staffName,
+      data.hotel,
+      data.department,
+      data.transferType,
+      data.transferFrom1,
+      data.transferTo1,
+      data.transferFrom2,
+      data.transferTo2,
+      data.serviceDate,
+      data.carrierTime,
+      data.expense,
+      data.total,
+      data.reason,
+      data.requestBy,
+      data.requestDate,
+      'Pending'
+    ]);
+    return ContentService.createTextOutput(JSON.stringify({result:'success', requestNumber:nextNum})).setMimeType(ContentService.MimeType.JSON);
+  } else if (data.action === 'approve') {
+    const reqNum = data.requestNumber;
+    const range = sheet.getDataRange();
+    const values = range.getValues();
+    for (let i = 1; i < values.length; i++) {
+      if (values[i][0] === reqNum) {
+        sheet.getRange(i+1,17).setValue('Approved');
+        return ContentService.createTextOutput(JSON.stringify({result:'approved'})).setMimeType(ContentService.MimeType.JSON);
+      }
+    }
+    return ContentService.createTextOutput(JSON.stringify({result:'not found'})).setMimeType(ContentService.MimeType.JSON);
+  }
+  return ContentService.createTextOutput(JSON.stringify({result:'unknown action'})).setMimeType(ContentService.MimeType.JSON);
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>The Sands Khaolak Transportation Request</title>
+  <link rel="stylesheet" href="style.css" />
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+</head>
+<body>
+  <nav class="navbar">
+    <div class="menu-icon" id="menuToggle">&#9776;</div>
+    <ul class="menu" id="menu">
+      <li data-section="requestSection">Request</li>
+      <li data-section="hmSection">HM Approval</li>
+      <li data-section="exportSection">Export</li>
+    </ul>
+  </nav>
+
+  <section id="requestSection" class="page active">
+    <h1>Transportation Request</h1>
+    <form id="requestForm">
+      <div class="field">
+        <label>Request Number</label>
+        <input type="text" id="requestNumber" name="requestNumber" readonly />
+      </div>
+      <div class="field">
+        <label>Staff Name</label>
+        <input type="text" id="staffName" required />
+      </div>
+      <div class="field">
+        <label>Hotel</label>
+        <select id="hotel" required>
+          <option value="The Sands Khaolak">The Sands Khaolak</option>
+          <option value="The Waters Khaolak">The Waters Khaolak</option>
+          <option value="The Little Shore Khaolak">The Little Shore Khaolak</option>
+          <option value="The Leaf Oceanside">The Leaf Oceanside</option>
+          <option value="The Leaf on The Sands">The Leaf on The Sands</option>
+        </select>
+      </div>
+      <div class="field">
+        <label>Department</label>
+        <select id="department" required>
+          <option value="AC">AC</option>
+          <option value="CR">CR</option>
+          <option value="EN">EN</option>
+          <option value="EX">EX</option>
+          <option value="FB">FB</option>
+          <option value="FO">FO</option>
+          <option value="HK">HK</option>
+          <option value="IT">IT</option>
+          <option value="KC">KC</option>
+          <option value="HR">HR</option>
+          <option value="SA">SA</option>
+          <option value="SPA">SPA</option>
+          <option value="TLKL">TLKL</option>
+          <option value="TN">TN</option>
+          <option value="MELON">MELON</option>
+          <option value="ENS">ENS</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label>Transfer Type</label>
+        <select id="transferType" required>
+          <option value="one">Transfer one way</option>
+          <option value="round">Transfer round trip</option>
+        </select>
+      </div>
+
+      <div id="transferFields">
+        <div class="field">
+          <label>Transfer From</label>
+          <input type="text" id="transferFrom1" required />
+        </div>
+        <div class="field">
+          <label>Transfer To</label>
+          <input type="text" id="transferTo1" required />
+        </div>
+        <div class="field round-only">
+          <label>Return From</label>
+          <input type="text" id="transferFrom2" />
+        </div>
+        <div class="field round-only">
+          <label>Return To</label>
+          <input type="text" id="transferTo2" />
+        </div>
+      </div>
+
+      <div class="field">
+        <label>Service Date</label>
+        <input type="datetime-local" id="serviceDate" required />
+      </div>
+      <div class="field">
+        <label>Carrier Time</label>
+        <input type="datetime-local" id="carrierTime" required />
+      </div>
+      <div class="field">
+        <label>Expense</label>
+        <input type="text" id="expense" />
+      </div>
+      <div class="field">
+        <label>Total (Baht)</label>
+        <input type="number" id="total" />
+      </div>
+      <div class="field">
+        <label>Reason</label>
+        <input type="text" id="reason" />
+      </div>
+      <div class="field">
+        <label>Request by</label>
+        <input type="text" id="requestBy" />
+      </div>
+      <div class="field">
+        <label>Request Date</label>
+        <input type="datetime-local" id="requestDate" />
+      </div>
+      <button type="submit">Submit</button>
+    </form>
+
+    <h2>History</h2>
+    <table id="historyTable">
+      <thead>
+        <tr>
+          <th>Request No.</th>
+          <th>Staff</th>
+          <th>Department</th>
+          <th>Service Date</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <h2>Usage by Department</h2>
+    <canvas id="deptChart"></canvas>
+  </section>
+
+  <section id="hmSection" class="page">
+    <h1>HM Approval</h1>
+    <div class="field">
+      <label>Select Request</label>
+      <select id="hmRequestSelect"></select>
+    </div>
+    <div id="hmDetails"></div>
+    <button id="approveBtn">Approve</button>
+  </section>
+
+  <section id="exportSection" class="page">
+    <h1>Export Request</h1>
+    <div class="field">
+      <label>Select Request</label>
+      <select id="exportRequestSelect"></select>
+    </div>
+    <div id="exportDetails"></div>
+    <button id="exportBtn">Download PDF</button>
+  </section>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,163 @@
+const scriptUrl = 'https://script.google.com/macros/s/AKfycbwEPWbRkm0TY1sdNtYx2tvcOxwncDDQnA0KbIORCUHuJ_fZa8SjaPsU3Mo2ZzXg2fbo/exec';
+let allData = [];
+
+// Navigation
+const menuToggle = document.getElementById('menuToggle');
+const menu = document.getElementById('menu');
+menuToggle.addEventListener('click', () => {
+  menu.style.display = menu.style.display === 'block' ? 'none' : 'block';
+});
+menu.querySelectorAll('li').forEach(li => {
+  li.addEventListener('click', () => {
+    document.querySelectorAll('.page').forEach(p => p.classList.remove('active'));
+    document.getElementById(li.dataset.section).classList.add('active');
+    menu.style.display = 'none';
+  });
+});
+
+// Transfer type toggle
+const transferType = document.getElementById('transferType');
+transferType.addEventListener('change', updateTransferType);
+function updateTransferType() {
+  const round = transferType.value === 'round';
+  document.querySelectorAll('.round-only').forEach(el => {
+    el.style.display = round ? 'block' : 'none';
+  });
+}
+updateTransferType();
+
+// Load initial data
+async function loadData() {
+  const res = await fetch(`${scriptUrl}?action=read`);
+  allData = await res.json();
+  fillHistory();
+  fillRequestNumber();
+  fillDropdowns();
+  buildChart();
+}
+loadData();
+
+function fillHistory() {
+  const tbody = document.querySelector('#historyTable tbody');
+  tbody.innerHTML = '';
+  allData.forEach(row => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${row.requestNumber}</td><td>${row.staffName}</td><td>${row.department}</td><td>${row.serviceDate}</td><td>${row.status||''}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function fillRequestNumber() {
+  const next = allData.length + 1;
+  document.getElementById('requestNumber').value = `REQ-${String(next).padStart(5,'0')}`;
+}
+
+function fillDropdowns() {
+  const hmSelect = document.getElementById('hmRequestSelect');
+  const exportSelect = document.getElementById('exportRequestSelect');
+  hmSelect.innerHTML = ''; exportSelect.innerHTML='';
+  allData.forEach(row => {
+    const opt1 = document.createElement('option');
+    opt1.value = opt1.textContent = row.requestNumber;
+    hmSelect.appendChild(opt1);
+    const opt2 = document.createElement('option');
+    opt2.value = opt2.textContent = row.requestNumber;
+    exportSelect.appendChild(opt2);
+  });
+}
+
+function buildChart() {
+  const counts = {};
+  allData.forEach(r => counts[r.department] = (counts[r.department] || 0) + 1);
+  const ctx = document.getElementById('deptChart');
+  new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: Object.keys(counts),
+      datasets: [{
+        label: 'Requests',
+        data: Object.values(counts),
+        backgroundColor: '#3399ff'
+      }]
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false
+    }
+  });
+}
+
+// Submit form
+const requestForm = document.getElementById('requestForm');
+requestForm.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const data = {
+    action: 'submit',
+    requestNumber: document.getElementById('requestNumber').value,
+    staffName: document.getElementById('staffName').value,
+    hotel: document.getElementById('hotel').value,
+    department: document.getElementById('department').value,
+    transferType: document.getElementById('transferType').value,
+    transferFrom1: document.getElementById('transferFrom1').value,
+    transferTo1: document.getElementById('transferTo1').value,
+    transferFrom2: document.getElementById('transferFrom2').value,
+    transferTo2: document.getElementById('transferTo2').value,
+    serviceDate: document.getElementById('serviceDate').value,
+    carrierTime: document.getElementById('carrierTime').value,
+    expense: document.getElementById('expense').value,
+    total: document.getElementById('total').value,
+    reason: document.getElementById('reason').value,
+    requestBy: document.getElementById('requestBy').value,
+    requestDate: document.getElementById('requestDate').value
+  };
+  try {
+    const res = await fetch(scriptUrl, {
+      method: 'POST',
+      body: JSON.stringify(data)
+    });
+    const json = await res.json();
+    alert(json.result);
+    loadData();
+    requestForm.reset();
+    updateTransferType();
+  } catch (err) {
+    alert('Submit failed');
+  }
+});
+
+// HM approval
+document.getElementById('hmRequestSelect').addEventListener('change', showHmDetails);
+function showHmDetails() {
+  const val = document.getElementById('hmRequestSelect').value;
+  const row = allData.find(r => r.requestNumber === val);
+  const div = document.getElementById('hmDetails');
+  if (!row) {div.textContent=''; return;}
+  div.innerHTML = `<p>Staff: ${row.staffName}</p><p>Department: ${row.department}</p>`;
+}
+
+document.getElementById('approveBtn').addEventListener('click', async () => {
+  const val = document.getElementById('hmRequestSelect').value;
+  if (!val) return;
+  try {
+    const res = await fetch(scriptUrl, {
+      method: 'POST',
+      body: JSON.stringify({action:'approve', requestNumber: val})
+    });
+    const json = await res.json();
+    alert(json.result);
+    loadData();
+  } catch (err) {
+    alert('Approve failed');
+  }
+});
+
+// Export
+ document.getElementById('exportRequestSelect').addEventListener('change', showExport);
+ function showExport() {
+   const val = document.getElementById('exportRequestSelect').value;
+   const row = allData.find(r => r.requestNumber === val);
+   const div = document.getElementById('exportDetails');
+   if (!row) {div.textContent=''; return;}
+   div.innerHTML = `<p>Request No: ${row.requestNumber}</p><p>Staff: ${row.staffName}</p><p>Department: ${row.department}</p><p>Service Date: ${row.serviceDate}</p>`;
+ }
+ document.getElementById('exportBtn').addEventListener('click', () => window.print());

--- a/style.css
+++ b/style.css
@@ -1,0 +1,70 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f0f8ff;
+  margin: 0;
+  color: #003366;
+}
+.navbar {
+  background: #003366;
+  color: white;
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+}
+.menu-icon {
+  font-size: 24px;
+  cursor: pointer;
+}
+.menu {
+  list-style: none;
+  display: none;
+  margin: 0;
+  padding: 0;
+}
+.menu li {
+  padding: 0.5rem 0;
+  cursor: pointer;
+}
+.menu li:hover {
+  text-decoration: underline;
+}
+.page {
+  display: none;
+  padding: 1rem;
+}
+.page.active {
+  display: block;
+}
+.field {
+  margin-bottom: 0.5rem;
+}
+.field label {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+#historyTable {
+  width: 100%;
+  border-collapse: collapse;
+}
+#historyTable th, #historyTable td {
+  border: 1px solid #003366;
+  padding: 0.25rem;
+  text-align: left;
+}
+#deptChart {
+  max-width: 600px;
+  margin: 1rem auto;
+}
+.round-only {
+  display: none;
+}
+@media (min-width: 600px) {
+  .menu {
+    display: flex;
+    flex: 1;
+    justify-content: flex-end;
+  }
+  .menu li {
+    margin-left: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add single-page transportation request form with history, charts, approval and export sections
- include blue/white styling and client-side logic to interact with Google Apps Script endpoint
- provide sample Google Apps Script for saving, reading and approving requests in Google Sheets

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b86e829b088321b61b096176f931aa